### PR TITLE
Feature/DCL-19 -  Remove username support from /register api and take full name instead

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,9 +26,6 @@ jobs:
       - name: 🧪 Run Unit Tests
         run: mvn test
 
-      - name: 🧪 Run Unit Tests
-        run: mvn test
-
       - name: 📦 Package App (no tests)
         run: mvn package -DskipTests
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,98 +1,120 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.devcircle.auth</groupId>
-	<artifactId>auth-service</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>auth-service</name>
-	<description>auth-service for devcircle project</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
-	<dependencies>
-<dependency>
-    <groupId>org.postgresql</groupId>
-    <artifactId>postgresql</artifactId>
-</dependency>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.devcircle.auth</groupId>
+    <artifactId>auth-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>auth-service</name>
+    <description>auth-service for devcircle project</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-  <groupId>com.h2database</groupId>
-  <artifactId>h2</artifactId>
-  <scope>test</scope>
-</dependency>
-<dependency>
-  <groupId>org.springframework.boot</groupId>
-  <artifactId>spring-boot-starter-test</artifactId>
-  <scope>test</scope>
-</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-<dependency>
-    <groupId>org.springdoc</groupId>
-    <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-    <version>2.3.0</version>
-</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-    <groupId>com.auth0</groupId>
-    <artifactId>java-jwt</artifactId>
-    <version>4.4.0</version>
-</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.4.0</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-security</artifactId>
-</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito integration with JUnit 5 -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+    
+            <scope>test</scope>
+        </dependency>
+
+  
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+    
+            <scope>test</scope>
+        </dependency>
 
 		
-	</dependencies>
+    </dependencies>
 
 	
 

--- a/src/main/java/com/devcircle/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/devcircle/auth/dto/RegisterRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 
 public class RegisterRequest {
 
-    @NotBlank(message = "Username is required.")
-    private String username;
+    @NotBlank(message = "Full name is required.")
+    private String fullName;
 
     @NotBlank(message = "Email is required.")
     @Email(message = "Email is not valid.")
@@ -15,8 +15,8 @@ public class RegisterRequest {
     @NotBlank(message = "Password is required.")
     private String password;
 
-    public String getUsername() {
-        return username;
+    public String getFullName() {
+        return fullName;
     }
 
     public String getEmail() {
@@ -27,8 +27,8 @@ public class RegisterRequest {
         return password;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
     }
 
     public void setEmail(String email) {

--- a/src/main/java/com/devcircle/auth/model/User.java
+++ b/src/main/java/com/devcircle/auth/model/User.java
@@ -19,8 +19,8 @@ public class User {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
-    private String username;
+    @Column(name = "full_name", nullable = true)
+    private String fullName;
 
     @Column(nullable = false, unique = true)
     private String email;
@@ -36,9 +36,9 @@ public class User {
 
     }
 
-    public User(UUID id, String username, String email, String password, String bio, LocalDateTime createdAt) {
+    public User(UUID id, String fullName, String email, String password, String bio, LocalDateTime createdAt) {
         this.id = id;
-        this.username = username;
+        this.fullName = fullName;
         this.email = email;
         this.password = password;
         this.bio = bio;
@@ -49,8 +49,8 @@ public class User {
         return id;
     }
 
-    public String getUsername() {
-        return username;
+    public String getFullName() {
+        return fullName;
     }
 
     public String getEmail() {
@@ -73,8 +73,8 @@ public class User {
         this.id = id;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
     }
 
     public void setEmail(String email) {
@@ -108,9 +108,9 @@ public class User {
         return Objects.hash(id);
     }
 
-    public static User build(String username, String email, String password, String bio) {
+    public static User build(String fullName, String email, String password, String bio) {
         User u = new User();
-        u.setUsername(username);
+        u.setFullName(fullName);
         u.setEmail(email);
         u.setPassword(password);
         u.setBio(bio);

--- a/src/main/java/com/devcircle/auth/model/User.java
+++ b/src/main/java/com/devcircle/auth/model/User.java
@@ -19,7 +19,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
-    @Column(name = "full_name", nullable = true)
+    @Column(name = "full_name", nullable = false)
     private String fullName;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/devcircle/auth/repository/UserRepository.java
+++ b/src/main/java/com/devcircle/auth/repository/UserRepository.java
@@ -11,10 +11,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByUsername(String username);
-
     boolean existsByEmail(String email);
-
-    boolean existsByUsername(String username);
 
 }

--- a/src/main/java/com/devcircle/auth/service/UserService.java
+++ b/src/main/java/com/devcircle/auth/service/UserService.java
@@ -1,6 +1,5 @@
 package com.devcircle.auth.service;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,17 +26,13 @@ public class UserService {
     }
 
     public UUID register(RegisterRequest request) {
-        // TODO: Check email, username already exists
 
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new DuplicateResourceException("Email is already in use.");
         }
-        if (userRepository.existsByUsername(request.getUsername())) {
-            throw new DuplicateResourceException("Username is already in use.");
-        }
 
         String hashedPassword = encoder.encode(request.getPassword());
-        User user = User.build(request.getUsername(), request.getEmail(), hashedPassword, null);
+        User user = User.build(request.getFullName(), request.getEmail(), hashedPassword, null);
 
         return userRepository.save(user).getId();
     }

--- a/src/test/java/com/devcircle/auth/repository/UserRepositoryTest.java
+++ b/src/test/java/com/devcircle/auth/repository/UserRepositoryTest.java
@@ -1,15 +1,18 @@
-
 package com.devcircle.auth.repository;
-
-import com.devcircle.auth.model.User;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.devcircle.auth.model.User;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -19,16 +22,34 @@ public class UserRepositoryTest {
     private UserRepository userRepository;
 
     @Test
-    public void shouldSaveUserSuccessfully() {
+    public void shouldSaveAndFindByEmail() {
         User user = new User();
-        user.setUsername("vikram");
+        user.setFullName("Vikram Bhat");
         user.setEmail("vikram@dc.com");
         user.setPassword("secret");
-
         userRepository.save(user);
 
+        // findAll
         List<User> allUsers = userRepository.findAll();
         assertEquals(1, allUsers.size());
-        assertEquals("vikram", allUsers.get(0).getUsername());
+        assertEquals("Vikram Bhat", allUsers.get(0).getFullName());
+
+        // findByEmail
+        var opt = userRepository.findByEmail("vikram@dc.com");
+        assertTrue(opt.isPresent());
+        assertEquals(user.getEmail(), opt.get().getEmail());
+
+        // existsByEmail
+        assertTrue(userRepository.existsByEmail("vikram@dc.com"));
+        assertFalse(userRepository.existsByEmail("other@dc.com"));
+    }
+
+    @Test
+    void shouldEnforceUniqueEmailConstraint() {
+        User u1 = User.build("A", "a@dc.com", "pw", null);
+        userRepository.saveAndFlush(u1);
+
+        User u2 = User.build("B", "a@dc.com", "pw2", null);
+        assertThrows(DataIntegrityViolationException.class, () -> userRepository.saveAndFlush(u2));
     }
 }

--- a/src/test/java/com/devcircle/auth/service/UserServiceTest.java
+++ b/src/test/java/com/devcircle/auth/service/UserServiceTest.java
@@ -1,0 +1,116 @@
+package com.devcircle.auth.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import com.devcircle.auth.dto.LoginRequest;
+import com.devcircle.auth.dto.RegisterRequest;
+import com.devcircle.auth.exception.DuplicateResourceException;
+import com.devcircle.auth.exception.InvalidCredentialsException;
+import com.devcircle.auth.model.User;
+import com.devcircle.auth.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void registerSuccess_returnsNewUuid() {
+        var req = new RegisterRequest();
+        req.setFullName("Vikram Bhat");
+        req.setEmail("info@google.com");
+        req.setPassword("Simple123@");
+        when(userRepository.existsByEmail(req.getEmail())).thenReturn(false);
+        when(passwordEncoder.encode(req.getPassword())).thenReturn("mockEncodedPassword");
+
+        var saved = User.build(req.getFullName(), req.getEmail(), "mockEncodedPassword", null);
+        UUID fakeId = UUID.randomUUID();
+        saved.setId(fakeId);
+        when(userRepository.save(any())).thenReturn(saved);
+
+        UUID result = userService.register(req);
+        assertEquals(fakeId, result);
+
+        // verify repo.save was called with a User whose fields match
+        verify(userRepository).save(argThat(u -> u.getFullName().equals(req.getFullName()) &&
+                u.getEmail().equals(req.getEmail()) &&
+                u.getPassword().equals("mockEncodedPassword")));
+    }
+
+    @Test
+    void register_whenEmailExistsThrowDuplicateResourceException() {
+        var req = new RegisterRequest();
+        req.setFullName("Vikram Bhat");
+        req.setEmail("info@google.com");
+        req.setPassword("Simple123@");
+        when(userRepository.existsByEmail(req.getEmail())).thenReturn(true);
+
+        assertThrows(DuplicateResourceException.class, () -> {
+            userService.register(req);
+        });
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void login_whenEmailNotFound_throwsInvalidCredentials() {
+        var req = new LoginRequest();
+        req.setEmail("nouser@dc.com");
+        req.setPassword("pw");
+        when(userRepository.findByEmail(req.getEmail()))
+                .thenReturn(Optional.empty());
+
+        assertThrows(InvalidCredentialsException.class, () -> userService.login(req));
+    }
+
+    @Test
+    void login_whenPasswordWrong_throwsInvalidCredentials() {
+        var req = new LoginRequest();
+        req.setEmail("u@dc.com");
+        req.setPassword("wrongpw");
+        User u = User.build("U", req.getEmail(), "storedHash", null);
+        when(userRepository.findByEmail(req.getEmail()))
+                .thenReturn(Optional.of(u));
+        when(passwordEncoder.matches("wrongpw", "storedHash")).thenReturn(false);
+
+        assertThrows(InvalidCredentialsException.class, () -> userService.login(req));
+    }
+
+    @Test
+    void login_whenCredentialsValid_returnsJwt() {
+        var req = new LoginRequest();
+        req.setEmail("vikram@dc.com");
+        req.setPassword("rightpw");
+        User u = User.build("Vikram", "vikram@dc.com", "hash123", null);
+        when(userRepository.findByEmail("vikram@dc.com"))
+                .thenReturn(Optional.of(u));
+        when(passwordEncoder.matches("rightpw", "hash123")).thenReturn(true);
+        when(jwtService.generateToken("vikram@dc.com")).thenReturn("tokenXYZ");
+
+        String token = userService.login(req);
+        assertEquals("tokenXYZ", token);
+    }
+
+}


### PR DESCRIPTION
Changes in the branch:

1. removed duplicate test running instance from yaml for ci/cd
2. modified User dto, model, service and repository with changes persisting to removal of username and adding of full name
3. added mock support
4. added coverage for UserService and UserRepository in tests

closes: https://bailuvikrambhat.atlassian.net/jira/software/projects/DCL/boards/1?selectedIssue=DCL-19
