### PR TITLE
Feature/dcl 29 return jwt for register endpoint

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,13 @@ name: 🚀 DevCircle Backend CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "sprint*"
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "sprint*"
 
 jobs:
   build:

--- a/src/main/java/com/devcircle/auth/controller/AuthController.java
+++ b/src/main/java/com/devcircle/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.devcircle.auth.dto.LoginRequest;
+import com.devcircle.auth.dto.LoginResponse;
 import com.devcircle.auth.dto.RegisterRequest;
 import com.devcircle.auth.dto.RegisterResponse;
 import com.devcircle.auth.service.UserService;
@@ -30,13 +31,13 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody @Valid RegisterRequest request) {
         RegisterResponse response = userService.register(request);
-        URI location = URI.create("/users/" + response.uuid());
+        URI location = URI.create("/users/" + response.userId());
         return ResponseEntity.status(HttpStatus.CREATED).location(location).body(response);
     }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid LoginRequest request) {
-        String token = userService.login(request);
-        return ResponseEntity.ok(Map.of("message", "Login successful", "token", token));
+        LoginResponse response = userService.login(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/devcircle/auth/controller/AuthController.java
+++ b/src/main/java/com/devcircle/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.devcircle.auth.controller;
 
+import java.net.URI;
 import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devcircle.auth.dto.LoginRequest;
 import com.devcircle.auth.dto.RegisterRequest;
+import com.devcircle.auth.dto.RegisterResponse;
 import com.devcircle.auth.service.UserService;
 
 import jakarta.validation.Valid;
@@ -26,10 +29,9 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody @Valid RegisterRequest request) {
-        var userId = userService.register(request);
-        return ResponseEntity.ok(Map.of(
-                "message", "User registered successfully.",
-                "userId", userId));
+        RegisterResponse response = userService.register(request);
+        URI location = URI.create("/users/" + response.uuid());
+        return ResponseEntity.status(HttpStatus.CREATED).location(location).body(response);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/devcircle/auth/dto/LoginResponse.java
+++ b/src/main/java/com/devcircle/auth/dto/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.devcircle.auth.dto;
+
+import java.util.UUID;
+
+public record LoginResponse(UUID userId, String token) {
+
+}

--- a/src/main/java/com/devcircle/auth/dto/RegisterResponse.java
+++ b/src/main/java/com/devcircle/auth/dto/RegisterResponse.java
@@ -1,0 +1,6 @@
+package com.devcircle.auth.dto;
+
+import java.util.UUID;
+
+public record RegisterResponse(UUID uuid, String token, String message) {
+}

--- a/src/main/java/com/devcircle/auth/dto/RegisterResponse.java
+++ b/src/main/java/com/devcircle/auth/dto/RegisterResponse.java
@@ -2,5 +2,5 @@ package com.devcircle.auth.dto;
 
 import java.util.UUID;
 
-public record RegisterResponse(UUID uuid, String token, String message) {
+public record RegisterResponse(UUID userId, String token, String message) {
 }

--- a/src/main/java/com/devcircle/auth/service/UserService.java
+++ b/src/main/java/com/devcircle/auth/service/UserService.java
@@ -4,6 +4,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.devcircle.auth.dto.LoginRequest;
+import com.devcircle.auth.dto.LoginResponse;
 import com.devcircle.auth.dto.RegisterRequest;
 import com.devcircle.auth.dto.RegisterResponse;
 import com.devcircle.auth.exception.DuplicateResourceException;
@@ -38,13 +39,14 @@ public class UserService {
                 "Successfully created the user");
     }
 
-    public String login(LoginRequest request) {
+    public LoginResponse login(LoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new InvalidCredentialsException("Email id not found."));
         if (!encoder.matches(request.getPassword(), user.getPassword())) {
             throw new InvalidCredentialsException("Incorrect password.");
         }
-        return jwtService.generateToken(user.getEmail());
+        String jwt = jwtService.generateToken(user.getEmail());
+        return new LoginResponse(user.getId(), jwt);
     }
 
 }

--- a/src/main/java/com/devcircle/auth/service/UserService.java
+++ b/src/main/java/com/devcircle/auth/service/UserService.java
@@ -1,12 +1,11 @@
 package com.devcircle.auth.service;
 
-import java.util.UUID;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.devcircle.auth.dto.LoginRequest;
 import com.devcircle.auth.dto.RegisterRequest;
+import com.devcircle.auth.dto.RegisterResponse;
 import com.devcircle.auth.exception.DuplicateResourceException;
 import com.devcircle.auth.exception.InvalidCredentialsException;
 import com.devcircle.auth.model.User;
@@ -25,16 +24,18 @@ public class UserService {
         this.jwtService = jwtService;
     }
 
-    public UUID register(RegisterRequest request) {
+    public RegisterResponse register(RegisterRequest request) {
 
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new DuplicateResourceException("Email is already in use.");
         }
-
         String hashedPassword = encoder.encode(request.getPassword());
         User user = User.build(request.getFullName(), request.getEmail(), hashedPassword, null);
 
-        return userRepository.save(user).getId();
+        User savedUser = userRepository.save(user);
+        String jwt = jwtService.generateToken(savedUser.getEmail());
+        return new RegisterResponse(savedUser.getId(), jwt,
+                "Successfully created the user");
     }
 
     public String login(LoginRequest request) {


### PR DESCRIPTION
1. Added returning jwt token as part of register endpoint to login user
2. Added returning userId token as part of login endpoint to navigate user to dashboard
3. Added workflow for sprint* branches

Login endpoint:
`{
    "userId": "25201eff-483a-4b19-be31-7a3969e2cc61",
    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJraXNoYW5AZGMuY29tIiwiaWF0IjoxNzQ1NzY5OTM2LCJleHAiOjE3NDU4NTYzMzZ9.vPxRyDGJqdqBy8DgOQJfdgkH4b2eam3O_rrTPqLtC4M"
}`
![image](https://github.com/user-attachments/assets/0cbc316b-f61d-4ea6-a6d3-622f9a389961)

Register endpoint:
`{
    "userId": "5bd35972-6f38-4120-b339-31f0dc7f4ad3",
    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhc2tqZGZoQGxramRmaC5jb20iLCJpYXQiOjE3NDU3NzAwMjQsImV4cCI6MTc0NTg1NjQyNH0.kQD1GAoBKmx3LyIhdoryStPA96SSIC6e7nZj9-lZLR4",
    "message": "Successfully created the user"
}`
![image](https://github.com/user-attachments/assets/e035a4f5-e61d-4f11-9cee-00aa6c82f4cd)

