### PR TITLE
issue jwt token with custom secret key on uuid and update tests - ready to consume by splash-service

### DIFF
--- a/src/main/java/com/devcircle/auth/config/JwtConfig.java
+++ b/src/main/java/com/devcircle/auth/config/JwtConfig.java
@@ -1,0 +1,53 @@
+package com.devcircle.auth.config;
+
+import java.time.Clock;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.auth0.jwt.algorithms.Algorithm;
+
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+public class JwtConfig {
+    private String secret;
+    private long expiryMs;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String s) {
+        this.secret = s;
+    }
+
+    public long getExpiryMs() {
+        return expiryMs;
+    }
+
+    public void setExpiryMs(long e) {
+        this.expiryMs = e;
+    }
+
+    @Bean
+    @Primary
+    public Algorithm hmacAlgorithm() {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException("JWT secret must be supplied via JWT_SECRET env var or yml/ props!");
+        }
+        return Algorithm.HMAC256(secret);
+    }
+
+    @Bean
+    public long jwtExpiryMs() {
+        return expiryMs;
+    }
+
+    @Bean
+    public Clock systemClock() {
+        return Clock.systemUTC();
+    }
+
+}

--- a/src/main/java/com/devcircle/auth/service/JwtService.java
+++ b/src/main/java/com/devcircle/auth/service/JwtService.java
@@ -1,19 +1,56 @@
 package com.devcircle.auth.service;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.Date;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
 
 @Service
 public class JwtService {
-    private static final String SECRET = "devcircle-secret-123";
-    private static final long EXPIRY_MS = 86400000;
 
-    public String generateToken(String email) {
-        return JWT.create().withSubject(email).withIssuedAt(new Date())
-                .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRY_MS)).sign(Algorithm.HMAC256(SECRET));
+    private final Algorithm algorithm;
+    private final long expiryMs;
+    private final Clock clock;
+    private final JWTVerifier verifier;
+
+    public JwtService(Algorithm algorithm, Long jwtExpiryMs, Clock clock) {
+        this.algorithm = algorithm;
+        this.expiryMs = jwtExpiryMs;
+        this.clock = clock;
+        this.verifier = JWT.require(algorithm).build();
+    }
+
+    /**
+     * Issue a JWT where <strong>sub = userId</strong>.
+     *
+     * @param userId UUID (primary key in our DB)
+     * @param email  current e‑mail address
+     * @param roles  optional list of roles/scopes
+     */
+    public String generateToken(UUID userId,
+            String email,
+            Collection<String> roles) {
+
+        Instant now = clock.instant();
+
+        return JWT.create()
+                .withSubject(userId.toString())
+                .withClaim("email", email)
+                .withArrayClaim("roles", roles.toArray(new String[0]))
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(now.plusMillis(expiryMs)))
+                .sign(algorithm);
+    }
+
+    public DecodedJWT decode(String token) {
+        return verifier.verify(token);
     }
 }

--- a/src/main/java/com/devcircle/auth/service/UserService.java
+++ b/src/main/java/com/devcircle/auth/service/UserService.java
@@ -1,5 +1,9 @@
 package com.devcircle.auth.service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -34,7 +38,7 @@ public class UserService {
         User user = User.build(request.getFullName(), request.getEmail(), hashedPassword, null);
 
         User savedUser = userRepository.save(user);
-        String jwt = jwtService.generateToken(savedUser.getEmail());
+        String jwt = issueJwt(user.getId(), user.getEmail(), Collections.emptyList());
         return new RegisterResponse(savedUser.getId(), jwt,
                 "Successfully created the user");
     }
@@ -45,8 +49,12 @@ public class UserService {
         if (!encoder.matches(request.getPassword(), user.getPassword())) {
             throw new InvalidCredentialsException("Incorrect password.");
         }
-        String jwt = jwtService.generateToken(user.getEmail());
+        String jwt = issueJwt(user.getId(), user.getEmail(), Collections.emptyList());
         return new LoginResponse(user.getId(), jwt);
+    }
+
+    private String issueJwt(UUID userId, String email, List<String> roles) {
+        return jwtService.generateToken(userId, email, roles);
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,7 @@ spring.datasource.password=simple123#
 # hibernate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+# jwt
+jwt.secret = f3c2d1e4b5a6978879610fedcba987651a2b3c4d5e6f7081928374655f6e7d8c9d8c7b6a5f4e3d2c1b0a9876543210feabcdef0123456789fedcba9876543210
+jwt.expiry-ms = 86400000

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -4,3 +4,7 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
+
+# jwt
+jwt.secret = f3c2d1e4b5a6978879610fedcba987651a2b3c4d5e6f7081928374655f6e7d8c9d8c7b6a5f4e3d2c1b0a9876543210feabcdef0123456789fedcba9876543210
+jwt.expiry-ms = 86400000


### PR DESCRIPTION
As we were using pathparam and the way auth-service token issuance was written, it was impossible to connect splash-service with auth-service. this PR fixes the issue and now we are able to successfully get the user authenticated across service:
![image](https://github.com/user-attachments/assets/d7e054a9-67c7-403a-bfde-ac546b6778fc)
